### PR TITLE
商品削除機能を実装した

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :set_item, except: [:index, :new, :create]
-  before_action :authenticate_user!, only: [:new, :edit]
-  before_action :contributor_confirmation, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
+  before_action :contributor_confirmation, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -33,6 +33,12 @@ class ItemsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -36,9 +36,6 @@
       <% end %>
     <% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
     <div class="item-explain-box">
       <span><%= @item.info %></span>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-      <%= link_to "削除", "#item_path(@item.id)", data: { turbo_method: :delete }, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% else %>
       <% if user_signed_in? %>


### PR DESCRIPTION
## WHAT
商品削除機能

## WHY
ログインしているユーザが自分の商品を削除できるようになるため

### Gyazo
- ログアウトしている人が削除できない（テストするため削除ボタンを誰でも見えるようにした）：

https://github.com/y-mikata/furima-kagawa2023-setouchi_titans/assets/4024761/5e069c0e-12e6-4f9d-b166-9a10ac3ede3c

- 違うユーザーが削除できない（テストするため削除ボタンを誰でも見えるようにした）：

https://github.com/y-mikata/furima-kagawa2023-setouchi_titans/assets/4024761/fdf01880-088d-4afd-9202-a4ab4659f461

- 自分が出品した商品なら削除できる。そして、そのあとトップページに戻る：

https://github.com/y-mikata/furima-kagawa2023-setouchi_titans/assets/4024761/be86c0bd-044e-49f9-a640-26e05fd805b1

